### PR TITLE
Allow passing logos as raw bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Plantilla de informe para estudiantes de la Universidad Nacional de La Plata, es
 
 - `institucion`: el logo de la institución del informe.
   - `"unlp"`: Universidad Nacional de La Plata (por defecto)
-  - Si se desea usar un logo diferente, basta con escribir la ruta la logo
-- `unidad-academica`: el logo de la unidad académica del informe.
+  - Si se desea usar un logo diferente, basta con pasar el logo como `bytes` usando `read`. Ejemplo: `institucion: read("/assets/jedi.png", encoding: none),`
+- `unidad-academica`: el logo de la unidad académica del informe. Opciones:
   - `"informática"`: Facultad de Informática
   - `"ingeniería"`: Facultad de Ingeniería
-  - Si se desea usar un logo diferente, basta con escribir la ruta la logo
+  - Si se desea usar un logo diferente, basta con pasar el logo como `bytes` usando `read`. Ejemplo: `unidad-academica: read("/assets/hogwarts.png", encoding: none),`
   - Si la unidad académica de la UNLP no está en la lista, [creá un reporte](https://github.com/JuanM04/barcala/issues/new) con el link al logo y lo agregamos a la plantilla.
 - `asignatura`: el nombre de la asignatura (`str`).
 - `titulo` (`content`, opcional): el título más formal del informe, como `[Trabajo Práctico Nº 3]`.

--- a/src/types.typ
+++ b/src/types.typ
@@ -47,8 +47,8 @@
 #let parse-options(options) = z.parse(
   options,
   z.dictionary((
-    institucion: z.string(default: "unlp"),
-    unidad-academica: z.string(),
+    institucion: z.either(z.string(), z.bytes(), default: "unlp"),
+    unidad-academica: z.either(z.string(), z.bytes()),
     asignatura: z.content(),
     titulo: z.content(optional: true),
     equipo: z.content(optional: true),


### PR DESCRIPTION
## Description

Packages installed from an outisde source cannot access a project's files (source: [typst forum](https://forum.typst.app/t/how-to-receive-a-user-supplied-path-in-a-package-function/3063/2)). This prevents users of the package from using custom `institucion` and `unidad-academica` images without including the package's source files, i.e. when installing the package from universe through the available template.

The implemented solution allows these parameters to be `bytes`, which can be passed to `image()` in the same way as a path, keeping backwards compatiblity.

Example:

```typ
// Edit on top of /template/main.typ

...
#show: informe.with(
  unidad-academica: read("/test/banana.png", encoding: none),
  institucion: read("/test/banana.png", encoding: none),
  asignatura: "F0317 Física II",
  titulo: "Informe de Laboratorio Nº 2",
  equipo: "Grupo 3",
...
```

Outputs:

<img width="843" height="167" alt="image" src="https://github.com/user-attachments/assets/157d30a2-cb19-4e97-8fea-2f2c522bc700" />
